### PR TITLE
fix: use Cloud Build instead of Docker for image build

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -32,19 +32,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Configure Docker for GCR
+      - name: Build and push Docker image with Cloud Build
         run: |
-          gcloud auth configure-docker
+          gcloud builds submit --tag gcr.io/${{ secrets.GCP_PROJECT_ID }}/groupbuilder-api:${{ github.sha }} .
 
-      - name: Build Docker image
-        run: |
-          docker build -t gcr.io/${{ secrets.GCP_PROJECT_ID }}/groupbuilder-api:${{ github.sha }} \
-                       -t gcr.io/${{ secrets.GCP_PROJECT_ID }}/groupbuilder-api:latest .
-
-      - name: Push Docker image to GCR
-        run: |
-          docker push gcr.io/${{ secrets.GCP_PROJECT_ID }}/groupbuilder-api:${{ github.sha }}
-          docker push gcr.io/${{ secrets.GCP_PROJECT_ID }}/groupbuilder-api:latest
+          # Tag the SHA image as latest
+          gcloud container images add-tag \
+            gcr.io/${{ secrets.GCP_PROJECT_ID }}/groupbuilder-api:${{ github.sha }} \
+            gcr.io/${{ secrets.GCP_PROJECT_ID }}/groupbuilder-api:latest \
+            --quiet
 
       - name: Deploy to Cloud Run
         run: |


### PR DESCRIPTION
- Replace docker build/push with gcloud builds submit
- This matches the deploy.sh approach and handles permissions better
- Cloud Build runs in GCP infrastructure instead of GitHub runner