### PR TITLE
fix: suppress logs in Cloud Build to avoid permission errors

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build and push Docker image with Cloud Build
         run: |
-          gcloud builds submit --tag gcr.io/${{ secrets.GCP_PROJECT_ID }}/groupbuilder-api:${{ github.sha }} .
+          gcloud builds submit --tag gcr.io/${{ secrets.GCP_PROJECT_ID }}/groupbuilder-api:${{ github.sha }} --suppress-logs .
 
           # Tag the SHA image as latest
           gcloud container images add-tag \


### PR DESCRIPTION
- Add --suppress-logs flag to gcloud builds submit
- Build still waits for completion but doesn't stream logs
- Logs are still available in Cloud Console