### PR TITLE
fix: clear all env vars and secrets before redeploying

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -53,8 +53,9 @@ jobs:
             --cpu 4 \
             --timeout 300 \
             --max-instances 10 \
+            --clear-env-vars \
             --clear-secrets \
-            --set-env-vars "UPSTASH_REDIS_REST_URL=${{ secrets.UPSTASH_REDIS_REST_URL }},UPSTASH_REDIS_REST_TOKEN=${{ secrets.UPSTASH_REDIS_REST_TOKEN }},CORS_ORIGINS=${{ secrets.FRONTEND_URL }},FROM_EMAIL=${{ secrets.FROM_EMAIL }},FRONTEND_URL=${{ secrets.FRONTEND_URL }},SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }}"
+            --update-env-vars "UPSTASH_REDIS_REST_URL=${{ secrets.UPSTASH_REDIS_REST_URL }},UPSTASH_REDIS_REST_TOKEN=${{ secrets.UPSTASH_REDIS_REST_TOKEN }},CORS_ORIGINS=${{ secrets.FRONTEND_URL }},FROM_EMAIL=${{ secrets.FROM_EMAIL }},FRONTEND_URL=${{ secrets.FRONTEND_URL }},SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }}"
 
       - name: Show deployed service URL
         run: |


### PR DESCRIPTION
- Add --clear-env-vars to remove all existing env vars
- Use --update-env-vars instead of --set-env-vars
- This ensures clean state before applying new configuration