### PR TITLE
fix: strip whitespace from env vars and sanitize error messages

### DIFF
--- a/api/src/api/routers/upload.py
+++ b/api/src/api/routers/upload.py
@@ -85,6 +85,13 @@ async def upload_file(
             "session_id": session_id,
             "columns": list(participant_dataframe.columns)
         }
+    except HTTPException:
+        # Re-raise HTTP exceptions as-is (they already have user-friendly messages)
+        raise
     except Exception as e:
         logger.error(f"Failed to process file {file.filename}: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to process file: {str(e)}")
+        # Don't expose internal error details to user (could contain sensitive info)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to process file. Please check that your file is a valid Excel file with the required columns."
+        )

--- a/api/src/api/storage.py
+++ b/api/src/api/storage.py
@@ -167,8 +167,8 @@ def create_storage_backend() -> StorageBackend:
     Priority: Upstash REST (serverless-optimized) > Redis > In-memory
     """
     # First try Upstash REST (best for serverless environments)
-    upstash_url = os.getenv("UPSTASH_REDIS_REST_URL")
-    upstash_token = os.getenv("UPSTASH_REDIS_REST_TOKEN")
+    upstash_url = os.getenv("UPSTASH_REDIS_REST_URL", "").strip()
+    upstash_token = os.getenv("UPSTASH_REDIS_REST_TOKEN", "").strip()
 
     if upstash_url and upstash_token and UPSTASH_AVAILABLE:
         try:


### PR DESCRIPTION
- Strip UPSTASH_REDIS_REST_URL and TOKEN to remove newlines
- Don't expose internal error details to users (security)
- Log full error details for debugging but show generic message to user