### PR TITLE
fix: improve UX for recent uploads and edit mode

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -291,10 +291,10 @@ const LandingPage: React.FC = () => {
                   </Label>
                   <Select value={selectedRecentUpload} onValueChange={handleRecentUploadSelect}>
                     <SelectTrigger id="recent-uploads">
-                      <SelectValue placeholder="Choose a recent upload or upload new file" />
+                      <SelectValue placeholder="Select a previous upload" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="new-upload">Upload new file</SelectItem>
+                      <SelectItem value="new-upload">New upload</SelectItem>
                       {recentUploads.map((upload) => {
                         const timeAgo = getTimeAgo(upload.created_at)
                         return (

--- a/frontend/src/pages/TableAssignmentsPage.tsx
+++ b/frontend/src/pages/TableAssignmentsPage.tsx
@@ -414,7 +414,7 @@ const TableAssignmentsPage: React.FC = () => {
                     <RotateCw className="h-4 w-4 mr-2" />
                     Regenerate
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={handleClearAssignments} disabled={editMode}>
+                  <DropdownMenuItem onClick={handleClearAssignments}>
                     <X className="h-4 w-4 mr-2" />
                     Clear
                   </DropdownMenuItem>


### PR DESCRIPTION
- Change 'Upload new file' to 'New upload' (clearer, not action-like)
- Update placeholder to 'Select a previous upload' (more accurate)
- Allow Clear button to work in edit mode (discards unsaved changes)