### PR TITLE
fix: file picker now enabled by default with empty selection

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -324,9 +324,9 @@ const LandingPage: React.FC = () => {
                   type="file"
                   accept=".xlsx, .xls"
                   onChange={handleFileChange}
-                  disabled={selectedRecentUpload !== "new-upload"}
+                  disabled={selectedRecentUpload && selectedRecentUpload !== "new-upload"}
                 />
-                {selectedRecentUpload !== "new-upload" && (
+                {selectedRecentUpload && selectedRecentUpload !== "new-upload" && (
                   <p className="text-sm text-muted-foreground">
                     Using recent upload. Clear selection above to upload a new file.
                   </p>


### PR DESCRIPTION
- Fix disabled state to check if selectedRecentUpload exists
- Only disable file picker when a real upload is selected
- Only show 'Using recent upload' message when appropriate