### PR TITLE
fix: correct Cloud Run deployment flag

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -55,7 +55,7 @@ jobs:
             --max-instances 10 \
             --min-instances 0 \
             --set-env-vars "UPSTASH_REDIS_REST_URL=${{ secrets.UPSTASH_REDIS_REST_URL }},UPSTASH_REDIS_REST_TOKEN=${{ secrets.UPSTASH_REDIS_REST_TOKEN }},CORS_ORIGINS=${{ secrets.FRONTEND_URL }},FROM_EMAIL=${{ secrets.FROM_EMAIL }},FRONTEND_URL=${{ secrets.FRONTEND_URL }},SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }}" \
-            --startup-cpu-boost
+            --cpu-boost
 
       - name: Show deployed service URL
         run: |


### PR DESCRIPTION
Change --startup-cpu-boost to --cpu-boost. The former flag doesn't exist and was causing deployment failures with "unrecognized arguments" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)