### PR TITLE
feat: context-aware regeneration with absence preservation

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -15,6 +15,10 @@ Ideas, feature requests, and wishlist items. Not prioritized, not committed to.
 
 - ~~**User-friendly frontend error messages**~~ — Done (PR #91). Network errors and 5xx now show friendly messages; technical details logged to console. (2026-02)
 
+- **Improve Regenerate All Sessions modal copy** — Current copy undersells destruction: says "a completely new set of assignments" and "your current version will be saved" without explicitly naming that saved absences are lost. Should say so plainly. (2026-06)
+
+- **Worked examples in Help page** — Three real mid-flight scenarios users struggle with: (1) saving absences then regenerating a session, (2) discovering partner/linking requirements after sessions are generated, (3) discovering participants need to be separated after sessions are generated. Show the step-by-step correct flow for each. (2026-06)
+
 ## Chores
 
 - **Custom SMTP for Firebase Auth emails** — Firebase's sign-in link email template is non-editable (body is hardcoded, shows project ID "group-builder-backend" as app name). Custom domain (`noreply@group-builder.com`) and SPF/DKIM are already configured. To customize the email content: configure SMTP settings in Firebase Console → Authentication → Templates → SMTP settings to send through Resend. Then replace Firebase's `sendSignInLinkToEmail()` in `frontend/src/services/firebase.ts` with a backend endpoint that generates the sign-in link via Admin SDK (`generate_sign_in_with_email_link` — already used in `api/src/api/services/email_service.py` for invites) and sends a custom-branded email through Resend. Purely aesthetic — sign-in emails currently work and land in inbox. (2026-02)

--- a/api/src/api/routers/assignments.py
+++ b/api/src/api/routers/assignments.py
@@ -288,6 +288,109 @@ async def regenerate_assignments(
         )
 
 
+@router.post("/regenerate/{session_id}/with_absences")
+@limiter.limit("5/minute")
+async def regenerate_all_with_absences(
+    request: Request,
+    session_id: str = Path(
+        ..., min_length=36, max_length=36, pattern="^[a-f0-9-]{36}$"
+    ),
+    max_time_seconds: int = Query(120, ge=30, le=240),
+    per_session_absences: List[Dict[str, Any]] = Body(default=[]),
+    user: AuthUser = Depends(get_current_user),
+):
+    """
+    Regenerate all sessions with per-session absences, saving exactly one new version.
+
+    per_session_absences: [{"session_number": 1, "absent_participants": [...]}, ...]
+    Sessions not listed are solved with all participants present.
+    """
+    session_storage = get_session_storage()
+    if not session_storage.session_exists(session_id):
+        raise HTTPException(status_code=404, detail="Session not found.")
+
+    session_data = session_storage.get_session(session_id)
+    participants = session_data["participant_data"]
+    num_tables = session_data["num_tables"]
+    num_sessions = session_data["num_sessions"]
+
+    absence_map: Dict[int, List[Dict[str, Any]]] = {}
+    for entry in per_session_absences:
+        sn = entry.get("session_number")
+        absent = entry.get("absent_participants", [])
+        if sn and absent:
+            absence_map[int(sn)] = absent
+
+    # Full solve — all participants present
+    results = handle_generate_assignments(
+        participants, num_tables, num_sessions, max_time_seconds=max_time_seconds
+    )
+    if results["status"] != "success":
+        raise HTTPException(
+            status_code=400, detail=results.get("error", "Solver failed")
+        )
+
+    assignments = results["assignments"]
+
+    # Re-solve sessions with absences, keeping other sessions' pairings as history
+    for session_number, absent in absence_map.items():
+        if session_number < 1 or session_number > num_sessions:
+            continue
+        active = _get_active_participants(participants, absent)
+        if len(active) < num_tables:
+            logger.warning(
+                f"Skipping absence regen for session {session_number}: "
+                f"only {len(active)} active participants for {num_tables} tables"
+            )
+            continue
+        historical = _extract_pairings_from_sessions(
+            assignments, exclude_session=session_number
+        )
+        builder = GroupBuilder(
+            participants=active,
+            num_tables=num_tables,
+            num_sessions=1,
+            historical_pairings=historical,
+            solver_num_workers=4,
+        )
+        single_result = builder.generate_assignments(
+            max_time_seconds=min(60, max_time_seconds)
+        )
+        if single_result["status"] == "success":
+            assignments[session_number - 1] = {
+                "session": session_number,
+                "tables": single_result["assignments"][0]["tables"],
+                "absentParticipants": absent,
+            }
+        else:
+            logger.warning(
+                f"Could not apply absences for session {session_number}, keeping full-solve result"
+            )
+
+    # Save exactly one new version
+    existing_versions = session_storage.get_result_versions(session_id)
+    version_num = len(existing_versions) + 1
+    version_id = f"v{version_num}"
+
+    session_storage.save_results(
+        session_id=session_id,
+        version_id=version_id,
+        assignments=assignments,
+        metadata={
+            "solution_quality": results.get("solution_quality"),
+            "solve_time": results.get("solve_time"),
+            "total_deviation": results.get("total_deviation"),
+            "max_time_seconds": max_time_seconds,
+            "regenerated": True,
+        },
+    )
+
+    logger.info(
+        f"Saved regen-with-absences result as {version_id} for session {session_id}"
+    )
+    return {"version_id": version_id, "assignments": assignments}
+
+
 @router.post("/regenerate/{session_id}/session/{session_number}")
 @limiter.limit(
     "20/minute"

--- a/api/src/api/routers/assignments.py
+++ b/api/src/api/routers/assignments.py
@@ -331,6 +331,7 @@ async def regenerate_all_with_absences(
         )
 
     assignments = results["assignments"]
+    absences_applied = False
 
     # Re-solve sessions with absences, keeping other sessions' pairings as history
     for session_number, absent in absence_map.items():
@@ -342,6 +343,9 @@ async def regenerate_all_with_absences(
                 f"Skipping absence regen for session {session_number}: "
                 f"only {len(active)} active participants for {num_tables} tables"
             )
+            # Preserve the absence record so it survives future regenerations,
+            # even though the tables keep the full-solve (everyone-present) layout.
+            assignments[session_number - 1]["absentParticipants"] = absent
             continue
         historical = _extract_pairings_from_sessions(
             assignments, exclude_session=session_number
@@ -362,27 +366,40 @@ async def regenerate_all_with_absences(
                 "tables": single_result["assignments"][0]["tables"],
                 "absentParticipants": absent,
             }
+            absences_applied = True
         else:
             logger.warning(
                 f"Could not apply absences for session {session_number}, keeping full-solve result"
             )
+            # Preserve the absence record even when the re-solve failed.
+            assignments[session_number - 1]["absentParticipants"] = absent
 
     # Save exactly one new version
     existing_versions = session_storage.get_result_versions(session_id)
     version_num = len(existing_versions) + 1
     version_id = f"v{version_num}"
 
+    # The full-solve quality metrics only describe the all-present solve. Once any
+    # session was re-solved with absences, those aggregate numbers no longer match
+    # the saved assignments, so drop them rather than report stale values.
+    metadata = {
+        "max_time_seconds": max_time_seconds,
+        "regenerated": True,
+    }
+    if absences_applied:
+        metadata["solution_quality"] = None
+        metadata["solve_time"] = None
+        metadata["total_deviation"] = None
+    else:
+        metadata["solution_quality"] = results.get("solution_quality")
+        metadata["solve_time"] = results.get("solve_time")
+        metadata["total_deviation"] = results.get("total_deviation")
+
     session_storage.save_results(
         session_id=session_id,
         version_id=version_id,
         assignments=assignments,
-        metadata={
-            "solution_quality": results.get("solution_quality"),
-            "solve_time": results.get("solve_time"),
-            "total_deviation": results.get("total_deviation"),
-            "max_time_seconds": max_time_seconds,
-            "regenerated": True,
-        },
+        metadata=metadata,
     )
 
     logger.info(

--- a/assignment_logic/src/assignment_logic/group_builder.py
+++ b/assignment_logic/src/assignment_logic/group_builder.py
@@ -596,11 +596,14 @@ class GroupBuilder:
             )
 
     def _run_solver(self, max_time_seconds=120):
+        import random
+
         self.solver = cp_model.CpSolver()
 
         self.solver.parameters.max_time_in_seconds = float(max_time_seconds)
         self.solver.parameters.num_search_workers = self.solver_num_workers
         self.solver.parameters.log_search_progress = False
+        self.solver.parameters.random_seed = random.randint(0, 2**31 - 1)
 
         logger.info(
             f"Starting CP-SAT solver (max time: {max_time_seconds:.1f}s, {self.solver.parameters.num_search_workers} workers)"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@craco/craco": "^7.1.0",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
@@ -16,6 +17,7 @@
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.90.21",
         "@testing-library/jest-dom": "^5.17.0",
@@ -4035,6 +4037,204 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
@@ -5258,6 +5458,276 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.0"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "proxy": "http://localhost:8000",
   "dependencies": {
     "@craco/craco": "^7.1.0",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
@@ -12,6 +13,7 @@
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.90.21",
     "@testing-library/jest-dom": "^5.17.0",

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/utils/cn"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("grid place-content-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/utils/cn"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -184,8 +184,14 @@ function HelpPage() {
             Generating Groups
           </h2>
           <p className="mb-4 text-slate-700 leading-relaxed">
-            Once your roster is ready, it's time to create your groups. At the bottom
-            of the Roster page, you'll see two dropdowns and a Generate button.
+            Once your roster is ready, it's time to create your groups. Scroll to the
+            bottom of the Roster page to find the generation controls.
+          </p>
+
+          <h3 className="text-xl font-semibold mb-2">First time: Fresh Start</h3>
+          <p className="mb-4 text-slate-700 leading-relaxed">
+            If you haven't generated groups yet, you'll see two dropdowns and a{" "}
+            <strong>Generate Assignments</strong> button.
           </p>
 
           <p className="mb-1 text-slate-700 leading-relaxed font-bold">
@@ -213,6 +219,24 @@ function HelpPage() {
             see a progress indicator while it works. When it's done, you'll be taken to
             the results page.
           </p>
+
+          <h3 className="text-xl font-semibold mt-8 mb-2">Already have groups: Regenerate or Fresh Start</h3>
+          <p className="mb-2 text-slate-700 leading-relaxed">
+            If you've generated groups before, the Roster page shows two tabs instead
+            of the flat form:
+          </p>
+          <ul className="list-disc pl-5 space-y-2 text-slate-700 leading-relaxed mb-4">
+            <li>
+              <strong>Regenerate</strong> — Re-runs the solver using your existing table
+              and session counts, and carries over any absences you've recorded in your
+              current version. Use this when you want a different arrangement but don't
+              need to change the structure.
+            </li>
+            <li>
+              <strong>Fresh Start</strong> — Lets you pick new table and session counts
+              and generates from scratch. Use this when your program structure has changed.
+            </li>
+          </ul>
 
           <WarningCallout>
             <p className="font-semibold mb-2">If something goes wrong:</p>
@@ -500,7 +524,11 @@ function HelpPage() {
           <p className="mb-2 text-slate-700 leading-relaxed">
             If you want a completely fresh set of assignments, click the{" "}
             <strong>⋮ menu</strong> and select <strong>"Regenerate All Sessions."</strong>{" "}
-            Regeneration takes up to 2 minutes — you can continue browsing while it runs.
+            A confirmation dialog will appear. If you have absences recorded, you'll see
+            a <strong>"Maintain saved absences"</strong> checkbox (checked by default) — leave
+            it on to carry those absences into the new version, or uncheck it to regenerate
+            with everyone present. Regeneration takes up to 2 minutes — you can continue
+            browsing while it runs.
           </p>
           <p className="mb-4 text-slate-700 leading-relaxed">
             Your previous version is not lost. Every time you regenerate, the results

--- a/frontend/src/pages/PreviousGroupsPage.tsx
+++ b/frontend/src/pages/PreviousGroupsPage.tsx
@@ -48,7 +48,7 @@ const PreviousGroupsPage: React.FC = () => {
         </p>
       ) : (
         <div className="space-y-3">
-          {sessions.map((session) => (
+          {sessions.map((session, index) => (
             <Card
               key={session.session_id}
               className="cursor-pointer hover:bg-accent/50 transition-colors"
@@ -58,7 +58,12 @@ const PreviousGroupsPage: React.FC = () => {
                 <div className="flex items-center gap-3">
                   <FolderOpen className="h-5 w-5 text-muted-foreground shrink-0" />
                   <div>
-                    <div className="font-medium">
+                    <div className="font-medium flex items-center gap-2">
+                      {index === 0 && (
+                        <span className="text-xs font-medium bg-primary text-primary-foreground px-1.5 py-0.5 rounded">
+                          Latest
+                        </span>
+                      )}
                       {session.created_at
                         ? new Date(session.created_at * 1000).toLocaleString(undefined, {
                             month: 'short', day: 'numeric', year: 'numeric',

--- a/frontend/src/pages/PreviousGroupsPage.tsx
+++ b/frontend/src/pages/PreviousGroupsPage.tsx
@@ -59,17 +59,17 @@ const PreviousGroupsPage: React.FC = () => {
                   <FolderOpen className="h-5 w-5 text-muted-foreground shrink-0" />
                   <div>
                     <div className="font-medium flex items-center gap-2">
-                      {index === 0 && (
-                        <span className="text-xs font-medium bg-primary text-primary-foreground px-1.5 py-0.5 rounded">
-                          Latest
-                        </span>
-                      )}
                       {session.created_at
                         ? new Date(session.created_at * 1000).toLocaleString(undefined, {
                             month: 'short', day: 'numeric', year: 'numeric',
                             hour: 'numeric', minute: '2-digit'
                           })
                         : 'Unknown date'}
+                      {index === 0 && (
+                        <span className="text-xs font-medium text-muted-foreground">
+                          Latest
+                        </span>
+                      )}
                     </div>
                     <div className="text-sm text-muted-foreground">
                       {session.num_participants} participants &middot; {session.num_tables} tables &middot; {session.num_sessions} session{session.num_sessions !== 1 ? 's' : ''}

--- a/frontend/src/pages/RosterPage.tsx
+++ b/frontend/src/pages/RosterPage.tsx
@@ -65,6 +65,18 @@ export function RosterPage() {
   const [generating, setGenerating] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('');
   const [maintainAbsences, setMaintainAbsences] = useState(true);
+  const [sourceAbsences, setSourceAbsences] = useState<SessionResult[] | null>(null);
+  const [absencesLoading, setAbsencesLoading] = useState(false);
+
+  useEffect(() => {
+    if (!sourceSession) return;
+    setAbsencesLoading(true);
+    authenticatedFetch(`/api/assignments/results/${sourceSession.session_id}`)
+      .then(res => res.ok ? res.json() : null)
+      .then((results: SessionResult[] | null) => setSourceAbsences(results ?? []))
+      .catch(() => setSourceAbsences([]))
+      .finally(() => setAbsencesLoading(false));
+  }, [sourceSession?.session_id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (rosterData) {
@@ -305,7 +317,7 @@ export function RosterPage() {
                   value="update"
                   className="flex-1 rounded-none rounded-tl-md border border-b-0 py-2.5 font-medium text-sm transition-colors data-[state=active]:bg-background data-[state=active]:shadow-none data-[state=active]:border-t-2 data-[state=active]:border-t-primary data-[state=active]:text-foreground data-[state=inactive]:bg-muted data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:bg-muted/70"
                 >
-                  Update Existing
+                  Regenerate
                 </TabsTrigger>
                 <TabsTrigger
                   value="fresh"
@@ -324,13 +336,34 @@ export function RosterPage() {
                     </span>
                   )}
                 </p>
-                <div className="flex items-center space-x-2">
-                  <Checkbox
-                    id="maintain-absences"
-                    checked={maintainAbsences}
-                    onCheckedChange={(checked: boolean | 'indeterminate') => setMaintainAbsences(checked === true)}
-                  />
-                  <Label htmlFor="maintain-absences">Maintain saved absences</Label>
+                <div className="space-y-2">
+                  <div className="flex items-center space-x-2">
+                    <Checkbox
+                      id="maintain-absences"
+                      checked={maintainAbsences}
+                      onCheckedChange={(checked: boolean | 'indeterminate') => setMaintainAbsences(checked === true)}
+                    />
+                    <Label htmlFor="maintain-absences">Maintain saved absences</Label>
+                  </div>
+                  <div className="ml-6 text-xs text-muted-foreground space-y-0.5">
+                    {absencesLoading ? (
+                      <span className="flex items-center gap-1"><Loader2 className="h-3 w-3 animate-spin" /> Loading absences…</span>
+                    ) : sourceAbsences === null ? null : sourceAbsences.every(s => !s.absentParticipants?.length) ? (
+                      <span>No absences recorded in the most recent session.</span>
+                    ) : (
+                      sourceAbsences
+                        .slice()
+                        .sort((a, b) => a.session - b.session)
+                        .map(s => (
+                          <div key={s.session}>
+                            <span className="font-medium">Session {s.session}:</span>{' '}
+                            {s.absentParticipants?.length
+                              ? s.absentParticipants.map(p => p.name).join(', ')
+                              : 'no absences'}
+                          </div>
+                        ))
+                    )}
+                  </div>
                 </div>
                 {(error || fetchError) && (
                   <Alert variant="destructive">

--- a/frontend/src/pages/RosterPage.tsx
+++ b/frontend/src/pages/RosterPage.tsx
@@ -5,6 +5,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from '@/components/ui/select';
@@ -15,8 +17,9 @@ import {
   upsertParticipant, deleteParticipant as apiDeleteParticipant,
   generateFromRoster,
 } from '@/api/roster';
-import { useRoster } from '@/hooks/queries';
+import { useRoster, useSessionsList } from '@/hooks/queries';
 import { useProgram } from '@/contexts/ProgramContext';
+import { authenticatedFetch } from '@/utils/apiClient';
 import { fetchWithRetry } from '@/utils/fetchWithRetry';
 import { API_BASE_URL } from '@/config/api';
 import { MAX_TABLES, MAX_SESSIONS } from '@/constants';
@@ -25,10 +28,35 @@ import { movePartnerAdjacent, sortPartnersAdjacent } from '@/utils/sortWithPartn
 
 type SaveStatus = 'saved' | 'saving' | 'error';
 
+interface SessionSummary {
+  session_id: string;
+  num_tables: number;
+  num_sessions: number;
+}
+
+interface AbsentParticipant {
+  name: string;
+  religion: string;
+  gender: string;
+  partner: string | null;
+  is_facilitator?: boolean;
+}
+
+interface SessionResult {
+  session: number;
+  absentParticipants?: AbsentParticipant[];
+}
+
 export function RosterPage() {
   const navigate = useNavigate();
   const { currentProgram } = useProgram();
   const { data: rosterData, isLoading: loading, error: fetchError } = useRoster();
+  const { data: sessionsData } = useSessionsList(currentProgram?.id ?? null);
+  const hasExistingSessions = Array.isArray(sessionsData) && sessionsData.length > 0;
+  const sourceSession: SessionSummary | null = hasExistingSessions
+    ? (sessionsData as SessionSummary[])[0]
+    : null;
+
   const [participants, setParticipants] = useState<RosterParticipant[]>([]);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('saved');
   const [error, setError] = useState<string | null>(null);
@@ -36,6 +64,7 @@ export function RosterPage() {
   const [numSessions, setNumSessions] = useState('5');
   const [generating, setGenerating] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('');
+  const [maintainAbsences, setMaintainAbsences] = useState(true);
 
   useEffect(() => {
     if (rosterData) {
@@ -154,10 +183,7 @@ export function RosterPage() {
         `${API_BASE_URL}/api/assignments/?session_id=${sessionId}&max_time_seconds=120`
       );
       if (!response.ok) throw new Error('Assignment generation failed');
-      const assignments = await response.json();
-      navigate(`/table-assignments?session=${sessionId}`, {
-        state: { assignments, sessionId },
-      });
+      navigate(`/table-assignments?session=${sessionId}`);
     } catch (err: any) {
       setError(err.message || 'Failed to generate assignments');
       setGenerating(false);
@@ -165,7 +191,79 @@ export function RosterPage() {
     }
   };
 
+  const handleRegenerateExisting = async () => {
+    if (!sourceSession) return;
+    setError(null);
+
+    const { num_tables: srcTables, num_sessions: srcSessions, session_id: srcSessionId } = sourceSession;
+
+    const facilitatorCount = participants.filter(p => p.is_facilitator).length;
+    if (facilitatorCount > 0 && facilitatorCount < srcTables) {
+      setError(`Need at least ${srcTables} facilitators for ${srcTables} tables (have ${facilitatorCount})`);
+      return;
+    }
+    if (participants.length < srcTables) {
+      setError(`Need at least ${srcTables} participants for ${srcTables} tables`);
+      return;
+    }
+
+    setGenerating(true);
+
+    try {
+      // Read per-session absences from the most recent session's results
+      let sessionsWithAbsences: { sessionNumber: number; absent: AbsentParticipant[] }[] = [];
+      if (maintainAbsences) {
+        setLoadingMessage('Reading saved absences...');
+        const resultsRes = await authenticatedFetch(`/api/assignments/results/${srcSessionId}`);
+        if (resultsRes.ok) {
+          const sourceResults: SessionResult[] = await resultsRes.json();
+          sessionsWithAbsences = sourceResults
+            .map(s => ({ sessionNumber: s.session, absent: s.absentParticipants || [] }))
+            .filter(s => s.absent.length > 0);
+        }
+      }
+
+      // Create new session from current roster
+      setLoadingMessage('Creating session from roster...');
+      const newSessionId = await generateFromRoster(currentProgram!.id, srcTables, srcSessions);
+
+      // Full solve — all participants present
+      setLoadingMessage('Generating assignments...');
+      const solveRes = await fetchWithRetry(
+        `${API_BASE_URL}/api/assignments/?session_id=${newSessionId}&max_time_seconds=120`
+      );
+      if (!solveRes.ok) throw new Error('Assignment generation failed');
+
+      // Re-solve each session that had absences, in order
+      if (sessionsWithAbsences.length > 0) {
+        setLoadingMessage(`Applying absences to ${sessionsWithAbsences.length} session(s)...`);
+        for (const { sessionNumber, absent } of sessionsWithAbsences) {
+          const regenRes = await authenticatedFetch(
+            `/api/assignments/regenerate/${newSessionId}/session/${sessionNumber}?max_time_seconds=60`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(absent),
+            }
+          );
+          if (!regenRes.ok) {
+            console.warn(`Could not apply absences for session ${sessionNumber}`);
+          }
+        }
+      }
+
+      navigate(`/table-assignments?session=${newSessionId}`);
+    } catch (err: any) {
+      setError(err.message || 'Failed to regenerate assignments');
+      setGenerating(false);
+      setLoadingMessage('');
+    }
+  };
+
   const canGenerate = participants.length >= parseInt(numTables) && participants.length > 0;
+  const canRegenerateExisting = sourceSession
+    ? participants.length >= sourceSession.num_tables && participants.length > 0
+    : false;
 
   if (loading) {
     return (
@@ -200,59 +298,174 @@ export function RosterPage() {
             onKeepTogetherToggle={handleKeepTogetherToggle}
           />
 
-          <div className="flex space-x-4">
-            <div className="flex-1">
-              <Label htmlFor="num-tables">Number of Tables</Label>
-              <Select value={numTables} onValueChange={setNumTables}>
-                <SelectTrigger id="num-tables">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {Array.from({ length: MAX_TABLES }, (_, i) => (
-                    <SelectItem key={i + 1} value={String(i + 1)}>{i + 1}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex-1">
-              <Label htmlFor="num-sessions">Number of Sessions</Label>
-              <Select value={numSessions} onValueChange={setNumSessions}>
-                <SelectTrigger id="num-sessions">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {Array.from({ length: MAX_SESSIONS }, (_, i) => (
-                    <SelectItem key={i + 1} value={String(i + 1)}>{i + 1}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
+          {hasExistingSessions ? (
+            <Tabs defaultValue="update">
+              <TabsList className="w-full h-auto p-0 bg-transparent border-b rounded-none gap-0">
+                <TabsTrigger
+                  value="update"
+                  className="flex-1 rounded-none rounded-tl-md border border-b-0 py-2.5 font-medium text-sm transition-colors data-[state=active]:bg-background data-[state=active]:shadow-none data-[state=active]:border-t-2 data-[state=active]:border-t-primary data-[state=active]:text-foreground data-[state=inactive]:bg-muted data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:bg-muted/70"
+                >
+                  Update Existing
+                </TabsTrigger>
+                <TabsTrigger
+                  value="fresh"
+                  className="flex-1 rounded-none rounded-tr-md border border-l-0 border-b-0 py-2.5 font-medium text-sm transition-colors data-[state=active]:bg-background data-[state=active]:shadow-none data-[state=active]:border-t-2 data-[state=active]:border-t-primary data-[state=active]:text-foreground data-[state=inactive]:bg-muted data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:bg-muted/70"
+                >
+                  Fresh Start
+                </TabsTrigger>
+              </TabsList>
 
-          {(error || fetchError) && (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Error</AlertTitle>
-              <AlertDescription>{error || (fetchError as Error)?.message}</AlertDescription>
-            </Alert>
+              <TabsContent value="update" className="space-y-4 border border-t-0 rounded-b-md p-4 mt-0">
+                <p className="text-sm text-muted-foreground">
+                  Regenerate all sessions using your current roster and constraints.
+                  {sourceSession && (
+                    <span className="ml-1">
+                      Keeps the existing layout: {sourceSession.num_tables} tables &times; {sourceSession.num_sessions} sessions.
+                    </span>
+                  )}
+                </p>
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="maintain-absences"
+                    checked={maintainAbsences}
+                    onCheckedChange={(checked: boolean | 'indeterminate') => setMaintainAbsences(checked === true)}
+                  />
+                  <Label htmlFor="maintain-absences">Maintain saved absences</Label>
+                </div>
+                {(error || fetchError) && (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Error</AlertTitle>
+                    <AlertDescription>{error || (fetchError as Error)?.message}</AlertDescription>
+                  </Alert>
+                )}
+                {generating && loadingMessage && (
+                  <Alert>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <AlertTitle>Generating</AlertTitle>
+                    <AlertDescription>{loadingMessage}</AlertDescription>
+                  </Alert>
+                )}
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={handleRegenerateExisting}
+                  disabled={!canRegenerateExisting || generating}
+                >
+                  {generating ? 'Generating...' : 'Regenerate All Sessions'}
+                </Button>
+              </TabsContent>
+
+              <TabsContent value="fresh" className="space-y-4 border border-t-0 rounded-b-md p-4 mt-0">
+                <p className="text-sm text-muted-foreground">
+                  Create a completely new set of sessions. All existing assignments and saved absences will be lost.
+                </p>
+                <div className="flex space-x-4">
+                  <div className="flex-1">
+                    <Label htmlFor="num-tables">Number of Tables</Label>
+                    <Select value={numTables} onValueChange={setNumTables}>
+                      <SelectTrigger id="num-tables">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Array.from({ length: MAX_TABLES }, (_, i) => (
+                          <SelectItem key={i + 1} value={String(i + 1)}>{i + 1}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex-1">
+                    <Label htmlFor="num-sessions">Number of Sessions</Label>
+                    <Select value={numSessions} onValueChange={setNumSessions}>
+                      <SelectTrigger id="num-sessions">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Array.from({ length: MAX_SESSIONS }, (_, i) => (
+                          <SelectItem key={i + 1} value={String(i + 1)}>{i + 1}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                {(error || fetchError) && (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Error</AlertTitle>
+                    <AlertDescription>{error || (fetchError as Error)?.message}</AlertDescription>
+                  </Alert>
+                )}
+                {generating && loadingMessage && (
+                  <Alert>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <AlertTitle>Generating</AlertTitle>
+                    <AlertDescription>{loadingMessage}</AlertDescription>
+                  </Alert>
+                )}
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={handleGenerate}
+                  disabled={!canGenerate || generating}
+                >
+                  {generating ? 'Generating...' : 'Generate Assignments'}
+                </Button>
+              </TabsContent>
+            </Tabs>
+          ) : (
+            <>
+              <div className="flex space-x-4">
+                <div className="flex-1">
+                  <Label htmlFor="num-tables">Number of Tables</Label>
+                  <Select value={numTables} onValueChange={setNumTables}>
+                    <SelectTrigger id="num-tables">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Array.from({ length: MAX_TABLES }, (_, i) => (
+                        <SelectItem key={i + 1} value={String(i + 1)}>{i + 1}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="flex-1">
+                  <Label htmlFor="num-sessions">Number of Sessions</Label>
+                  <Select value={numSessions} onValueChange={setNumSessions}>
+                    <SelectTrigger id="num-sessions">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Array.from({ length: MAX_SESSIONS }, (_, i) => (
+                        <SelectItem key={i + 1} value={String(i + 1)}>{i + 1}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              {(error || fetchError) && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertTitle>Error</AlertTitle>
+                  <AlertDescription>{error || (fetchError as Error)?.message}</AlertDescription>
+                </Alert>
+              )}
+              {generating && loadingMessage && (
+                <Alert>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <AlertTitle>Generating</AlertTitle>
+                  <AlertDescription>{loadingMessage}</AlertDescription>
+                </Alert>
+              )}
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={handleGenerate}
+                disabled={!canGenerate || generating}
+              >
+                {generating ? 'Generating...' : 'Generate Assignments'}
+              </Button>
+            </>
           )}
-
-          {generating && loadingMessage && (
-            <Alert>
-              <Loader2 className="h-4 w-4 animate-spin" />
-              <AlertTitle>Generating</AlertTitle>
-              <AlertDescription>{loadingMessage}</AlertDescription>
-            </Alert>
-          )}
-
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={handleGenerate}
-            disabled={!canGenerate || generating}
-          >
-            {generating ? 'Generating...' : 'Generate Assignments'}
-          </Button>
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/pages/RosterPage.tsx
+++ b/frontend/src/pages/RosterPage.tsx
@@ -225,17 +225,19 @@ export function RosterPage() {
     setGenerating(true);
 
     try {
-      // Read per-session absences from the most recent session's results
+      // Reuse the per-session absences already loaded on mount; only fall back to
+      // a fetch if they haven't finished loading yet.
       let sessionsWithAbsences: { sessionNumber: number; absent: AbsentParticipant[] }[] = [];
       if (maintainAbsences) {
-        setLoadingMessage('Reading saved absences...');
-        const resultsRes = await authenticatedFetch(`/api/assignments/results/${srcSessionId}`);
-        if (resultsRes.ok) {
-          const sourceResults: SessionResult[] = await resultsRes.json();
-          sessionsWithAbsences = sourceResults
-            .map(s => ({ sessionNumber: s.session, absent: s.absentParticipants || [] }))
-            .filter(s => s.absent.length > 0);
+        let sourceResults = sourceAbsences;
+        if (sourceResults === null) {
+          setLoadingMessage('Reading saved absences...');
+          const resultsRes = await authenticatedFetch(`/api/assignments/results/${srcSessionId}`);
+          sourceResults = resultsRes.ok ? await resultsRes.json() : [];
         }
+        sessionsWithAbsences = (sourceResults ?? [])
+          .map(s => ({ sessionNumber: s.session, absent: s.absentParticipants || [] }))
+          .filter(s => s.absent.length > 0);
       }
 
       // Create new session from current roster

--- a/frontend/src/pages/RosterPage.tsx
+++ b/frontend/src/pages/RosterPage.tsx
@@ -242,30 +242,21 @@ export function RosterPage() {
       setLoadingMessage('Creating session from roster...');
       const newSessionId = await generateFromRoster(currentProgram!.id, srcTables, srcSessions);
 
-      // Full solve — all participants present
+      // Solve all sessions, applying absences, in a single backend call
       setLoadingMessage('Generating assignments...');
-      const solveRes = await fetchWithRetry(
-        `${API_BASE_URL}/api/assignments/?session_id=${newSessionId}&max_time_seconds=120`
+      const perSessionAbsences = sessionsWithAbsences.map(s => ({
+        session_number: s.sessionNumber,
+        absent_participants: s.absent,
+      }));
+      const solveRes = await authenticatedFetch(
+        `/api/assignments/regenerate/${newSessionId}/with_absences?max_time_seconds=120`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(perSessionAbsences),
+        }
       );
       if (!solveRes.ok) throw new Error('Assignment generation failed');
-
-      // Re-solve each session that had absences, in order
-      if (sessionsWithAbsences.length > 0) {
-        setLoadingMessage(`Applying absences to ${sessionsWithAbsences.length} session(s)...`);
-        for (const { sessionNumber, absent } of sessionsWithAbsences) {
-          const regenRes = await authenticatedFetch(
-            `/api/assignments/regenerate/${newSessionId}/session/${sessionNumber}?max_time_seconds=60`,
-            {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(absent),
-            }
-          );
-          if (!regenRes.ok) {
-            console.warn(`Could not apply absences for session ${sessionNumber}`);
-          }
-        }
-      }
 
       queryClient.invalidateQueries({ queryKey: ['sessions', currentProgram?.id] });
       navigate(`/table-assignments?session=${newSessionId}`);

--- a/frontend/src/pages/RosterPage.tsx
+++ b/frontend/src/pages/RosterPage.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/api/roster';
 import { useRoster, useSessionsList } from '@/hooks/queries';
 import { useProgram } from '@/contexts/ProgramContext';
+import { useQueryClient } from '@tanstack/react-query';
 import { authenticatedFetch } from '@/utils/apiClient';
 import { fetchWithRetry } from '@/utils/fetchWithRetry';
 import { API_BASE_URL } from '@/config/api';
@@ -50,6 +51,7 @@ interface SessionResult {
 export function RosterPage() {
   const navigate = useNavigate();
   const { currentProgram } = useProgram();
+  const queryClient = useQueryClient();
   const { data: rosterData, isLoading: loading, error: fetchError } = useRoster();
   const { data: sessionsData } = useSessionsList(currentProgram?.id ?? null);
   const hasExistingSessions = Array.isArray(sessionsData) && sessionsData.length > 0;
@@ -195,6 +197,7 @@ export function RosterPage() {
         `${API_BASE_URL}/api/assignments/?session_id=${sessionId}&max_time_seconds=120`
       );
       if (!response.ok) throw new Error('Assignment generation failed');
+      queryClient.invalidateQueries({ queryKey: ['sessions', currentProgram?.id] });
       navigate(`/table-assignments?session=${sessionId}`);
     } catch (err: any) {
       setError(err.message || 'Failed to generate assignments');
@@ -264,6 +267,7 @@ export function RosterPage() {
         }
       }
 
+      queryClient.invalidateQueries({ queryKey: ['sessions', currentProgram?.id] });
       navigate(`/table-assignments?session=${newSessionId}`);
     } catch (err: any) {
       setError(err.message || 'Failed to regenerate assignments');

--- a/frontend/src/pages/TableAssignmentsPage.tsx
+++ b/frontend/src/pages/TableAssignmentsPage.tsx
@@ -946,13 +946,32 @@ const TableAssignmentsPage: React.FC = () => {
             <p className="text-sm text-muted-foreground">
               Your current version will be saved and you can switch back anytime.
             </p>
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="maintain-absences-regen"
-                checked={maintainAbsencesOnRegen}
-                onCheckedChange={(checked: boolean | 'indeterminate') => setMaintainAbsencesOnRegen(checked === true)}
-              />
-              <Label htmlFor="maintain-absences-regen">Maintain saved absences</Label>
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="maintain-absences-regen"
+                  checked={maintainAbsencesOnRegen}
+                  onCheckedChange={(checked: boolean | 'indeterminate') => setMaintainAbsencesOnRegen(checked === true)}
+                />
+                <Label htmlFor="maintain-absences-regen">Maintain saved absences</Label>
+              </div>
+              <div className="ml-6 text-xs text-muted-foreground space-y-0.5">
+                {assignments.every(s => !s.absentParticipants?.length) ? (
+                  <span>No absences recorded in this session.</span>
+                ) : (
+                  assignments
+                    .slice()
+                    .sort((a, b) => a.session - b.session)
+                    .map(s => (
+                      <div key={s.session}>
+                        <span className="font-medium">Session {s.session}:</span>{' '}
+                        {s.absentParticipants?.length
+                          ? s.absentParticipants.map(p => p.name).join(', ')
+                          : 'no absences'}
+                      </div>
+                    ))
+                )}
+              </div>
             </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => setShowRegenerateDialog(false)}>

--- a/frontend/src/pages/TableAssignmentsPage.tsx
+++ b/frontend/src/pages/TableAssignmentsPage.tsx
@@ -31,6 +31,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
 import { authenticatedFetch } from '@/utils/apiClient'
 import { useResultVersions, useAssignmentResults } from '@/hooks/queries'
 
@@ -84,6 +86,7 @@ const TableAssignmentsPage: React.FC = () => {
   const [selectedParticipantSlot, setSelectedParticipantSlot] = useState<{tableNum: number, participantIndex: number} | null>(null)
   const [clearSelectionKey, setClearSelectionKey] = useState(0)
   const [showRegenerateDialog, setShowRegenerateDialog] = useState<boolean>(false)
+  const [maintainAbsencesOnRegen, setMaintainAbsencesOnRegen] = useState<boolean>(true)
   const [regenerating, setRegenerating] = useState<boolean>(false)
   const [regenerateSuccess, setRegenerateSuccess] = useState<boolean>(false)
   const [newVersionId, setNewVersionId] = useState<string | null>(null)
@@ -277,8 +280,32 @@ const TableAssignmentsPage: React.FC = () => {
       }
 
       const result = await response.json()
+      let finalVersionId: string = result.version_id
+
+      // Apply per-session absences from current assignments if requested
+      if (maintainAbsencesOnRegen) {
+        const sessionsWithAbsences = assignments
+          .map(s => ({ sessionNumber: s.session, absent: s.absentParticipants || [] }))
+          .filter(s => s.absent.length > 0)
+
+        for (const { sessionNumber, absent } of sessionsWithAbsences) {
+          const regenRes = await authenticatedFetch(
+            `/api/assignments/regenerate/${sessionId}/session/${sessionNumber}?max_time_seconds=60&version_id=${finalVersionId}`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(absent),
+            }
+          )
+          if (regenRes.ok) {
+            const regenResult = await regenRes.json()
+            finalVersionId = regenResult.version_id
+          }
+        }
+      }
+
       // Save new version ID but don't auto-switch
-      setNewVersionId(result.version_id)
+      setNewVersionId(finalVersionId)
       setRegenerateSuccess(true)
 
       // Invalidate queries so versions list refreshes
@@ -919,6 +946,14 @@ const TableAssignmentsPage: React.FC = () => {
             <p className="text-sm text-muted-foreground">
               Your current version will be saved and you can switch back anytime.
             </p>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="maintain-absences-regen"
+                checked={maintainAbsencesOnRegen}
+                onCheckedChange={(checked: boolean | 'indeterminate') => setMaintainAbsencesOnRegen(checked === true)}
+              />
+              <Label htmlFor="maintain-absences-regen">Maintain saved absences</Label>
+            </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => setShowRegenerateDialog(false)}>
                 Cancel

--- a/frontend/src/pages/TableAssignmentsPage.tsx
+++ b/frontend/src/pages/TableAssignmentsPage.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { DEFAULT_SOLVER_TIMEOUT_SECONDS } from '@/constants'
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { Loader2, LayoutGrid, List, Edit, Undo2, MoreVertical, RotateCw, Check, Link, AlertCircle, Printer } from 'lucide-react'
+import { Loader2, LayoutGrid, List, Edit, Undo2, MoreVertical, RotateCw, Check, Link, AlertCircle, Printer, X } from 'lucide-react'
 import {
   Select,
   SelectContent,
@@ -239,6 +239,8 @@ const TableAssignmentsPage: React.FC = () => {
   const handleVersionChange = (versionId: string) => {
     setUndoStack([])
     setCurrentVersion(versionId)
+    setRegenerateSuccess(false)
+    setNewVersionId(null)
 
     // Update URL without reload
     const newUrl = versionId !== 'latest'
@@ -702,16 +704,27 @@ const TableAssignmentsPage: React.FC = () => {
 
           {regenerateSuccess && !regenerating && (
             <Alert className="mb-4 bg-green-50 border-green-200">
-              <div className="flex items-start justify-between">
+              <div className="flex items-start justify-between gap-2">
                 <div>
                   <AlertTitle>Regeneration Complete!</AlertTitle>
                   <AlertDescription>
                     New assignments saved as {newVersionId}
                   </AlertDescription>
                 </div>
-                <Button variant="outline" size="sm" onClick={handleViewNewAssignments}>
-                  View New Assignments
-                </Button>
+                <div className="flex items-center gap-2 shrink-0">
+                  <Button variant="outline" size="sm" onClick={handleViewNewAssignments}>
+                    View New Assignments
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0"
+                    onClick={() => { setRegenerateSuccess(false); setNewVersionId(null); }}
+                    aria-label="Dismiss"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
             </Alert>
           )}

--- a/frontend/src/pages/TableAssignmentsPage.tsx
+++ b/frontend/src/pages/TableAssignmentsPage.tsx
@@ -767,7 +767,6 @@ const TableAssignmentsPage: React.FC = () => {
                 <Select
                   value={currentSession.toString()}
                   onValueChange={(value) => setCurrentSession(parseInt(value))}
-                  disabled={editMode}
                 >
                   <SelectTrigger className="w-[180px]" aria-label="Select session">
                     <SelectValue placeholder="Select session" />
@@ -856,7 +855,7 @@ const TableAssignmentsPage: React.FC = () => {
                 <Button
                   variant="outline"
                   onClick={handlePreviousSession}
-                  disabled={currentSession === 1 || editMode}
+                  disabled={currentSession === 1}
                   size="sm"
                 >
                   ← Prev
@@ -864,7 +863,7 @@ const TableAssignmentsPage: React.FC = () => {
                 <Button
                   variant="outline"
                   onClick={handleNextSession}
-                  disabled={currentSession === assignments.length || editMode}
+                  disabled={currentSession === assignments.length}
                   size="sm"
                 >
                   Next →

--- a/frontend/src/pages/TableAssignmentsPage.tsx
+++ b/frontend/src/pages/TableAssignmentsPage.tsx
@@ -270,11 +270,21 @@ const TableAssignmentsPage: React.FC = () => {
         throw new Error('Session ID not found. Please upload a file again.')
       }
 
-      console.log('[Regenerate] Requesting regeneration with max_time_seconds:', DEFAULT_SOLVER_TIMEOUT_SECONDS)
-      const response = await authenticatedFetch(`/api/assignments/regenerate/${sessionId}?max_time_seconds=${DEFAULT_SOLVER_TIMEOUT_SECONDS}`, {
-        method: 'POST',
-        signal: controller.signal,
-      })
+      const perSessionAbsences = maintainAbsencesOnRegen
+        ? assignments
+            .filter(s => s.absentParticipants && s.absentParticipants.length > 0)
+            .map(s => ({ session_number: s.session, absent_participants: s.absentParticipants }))
+        : []
+
+      const response = await authenticatedFetch(
+        `/api/assignments/regenerate/${sessionId}/with_absences?max_time_seconds=${DEFAULT_SOLVER_TIMEOUT_SECONDS}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(perSessionAbsences),
+          signal: controller.signal,
+        }
+      )
 
       if (!response.ok) {
         const errorData = await response.json()
@@ -282,29 +292,7 @@ const TableAssignmentsPage: React.FC = () => {
       }
 
       const result = await response.json()
-      let finalVersionId: string = result.version_id
-
-      // Apply per-session absences from current assignments if requested
-      if (maintainAbsencesOnRegen) {
-        const sessionsWithAbsences = assignments
-          .map(s => ({ sessionNumber: s.session, absent: s.absentParticipants || [] }))
-          .filter(s => s.absent.length > 0)
-
-        for (const { sessionNumber, absent } of sessionsWithAbsences) {
-          const regenRes = await authenticatedFetch(
-            `/api/assignments/regenerate/${sessionId}/session/${sessionNumber}?max_time_seconds=60&version_id=${finalVersionId}`,
-            {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(absent),
-            }
-          )
-          if (regenRes.ok) {
-            const regenResult = await regenRes.json()
-            finalVersionId = regenResult.version_id
-          }
-        }
-      }
+      const finalVersionId: string = result.version_id
 
       // Save new version ID but don't auto-switch
       setNewVersionId(finalVersionId)

--- a/frontend/src/pages/admin/CreateProgramModal.tsx
+++ b/frontend/src/pages/admin/CreateProgramModal.tsx
@@ -29,6 +29,14 @@ export function CreateProgramModal({ open, onClose, onSuccess }: CreateProgramMo
   const [success, setSuccess] = useState(false);
   const [inviteLinks, setInviteLinks] = useState<Array<{email: string, invite_link: string, email_sent: boolean, error?: string}>>([]);
   const [partialFailure, setPartialFailure] = useState(false);
+  const [copiedEmail, setCopiedEmail] = useState<string | null>(null);
+
+  const handleCopyLink = (email: string, link: string) => {
+    navigator.clipboard.writeText(link).then(() => {
+      setCopiedEmail(email);
+      setTimeout(() => setCopiedEmail(null), 2000);
+    });
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -142,9 +150,9 @@ export function CreateProgramModal({ open, onClose, onSuccess }: CreateProgramMo
                               variant="outline"
                               size="sm"
                               type="button"
-                              onClick={() => navigator.clipboard.writeText(invite.invite_link)}
+                              onClick={() => handleCopyLink(invite.email, invite.invite_link)}
                             >
-                              Copy link
+                              {copiedEmail === invite.email ? 'Copied!' : 'Copy link'}
                             </Button>
                           </div>
                         </div>

--- a/frontend/src/pages/admin/ManageProgramModal.tsx
+++ b/frontend/src/pages/admin/ManageProgramModal.tsx
@@ -30,6 +30,15 @@ export function ManageProgramModal({ open, onClose, programId }: ManageProgramMo
   const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
   const [confirmRemove, setConfirmRemove] = useState<{ userId: string; email: string } | null>(null);
   const [failedInviteLink, setFailedInviteLink] = useState<string | null>(null);
+  const [copiedLink, setCopiedLink] = useState(false);
+
+  const handleCopyFailedLink = () => {
+    if (!failedInviteLink) return;
+    navigator.clipboard.writeText(failedInviteLink).then(() => {
+      setCopiedLink(true);
+      setTimeout(() => setCopiedLink(false), 2000);
+    });
+  };
 
   const { data: programDetails = null, isLoading: loading, error: fetchError } = useProgramDetails(programId, open);
 
@@ -253,11 +262,9 @@ export function ManageProgramModal({ open, onClose, programId }: ManageProgramMo
                       variant="outline"
                       size="sm"
                       type="button"
-                      onClick={() => {
-                        navigator.clipboard.writeText(failedInviteLink);
-                      }}
+                      onClick={handleCopyFailedLink}
                     >
-                      Copy link
+                      {copiedLink ? 'Copied!' : 'Copy link'}
                     </Button>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

- **Roster page tabs**: When sessions already exist, shows two tabs — **Regenerate** (same table/session config, carries over saved absences) and **Fresh Start** (pick new counts, wipes everything). Absent participants per session are shown in a preview below the checkbox before triggering.
- **Regenerate All**: New `POST /api/assignments/regenerate/{session_id}/with_absences` endpoint solves all sessions in one pass and saves exactly one version (vs. N+1 versions before). Dialog now includes a "Maintain saved absences" checkbox with a per-session absence list, and the success banner is dismissable.
- **Session navigation in edit mode**: Prev/Next and session dropdown no longer locked while editing.
- **Previous Groups**: "Latest" badge on most recent session to reduce confusion about which version is being used as the base for regeneration.
- **Copy link UX**: "Copied!" feedback on invite link copy buttons in both admin modals.
- **Stale cache fix**: Invalidates sessions TanStack Query cache after generating so the Roster page reflects new state immediately.
- **Solver determinism fix**: CP-SAT now gets a random seed per run, so repeated regeneration produces different arrangements.
- **HelpPage**: Updated Generating Groups and Regenerate All sections to match new UI.

## Test plan

- [ ] Roster page with no sessions: flat form with two dropdowns + Generate button
- [ ] Roster page with sessions: Regenerate / Fresh Start tabs appear; Regenerate tab shows absence preview if absences exist
- [ ] Regenerate tab generates successfully, lands on TableAssignments with correct version
- [ ] Fresh Start generates with new table/session counts, invalidates cache, lands on TableAssignments
- [ ] Regenerate All via ⋮ menu: single version bump, absences preserved when checkbox on, not preserved when off
- [ ] Regenerate All dialog shows per-session absence list
- [ ] Success banner dismisses on X click and on version switch
- [ ] Session Prev/Next navigable in edit mode
- [ ] Latest badge appears on most recent session in Previous Groups
- [ ] Copy invite link shows "Copied!" for 2 seconds in both CreateProgram and ManageProgram modals
- [ ] All solver tests pass: `cd assignment_logic && poetry run pytest tests/ -v`
- [ ] All API tests pass: `cd api && poetry run pytest`
- [ ] Frontend lint + tsc clean: `npm run lint && npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)